### PR TITLE
build: set dependabot updates to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:00"
       timezone: "America/Los_Angeles"
     labels:
@@ -13,8 +12,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:00"
       timezone: "America/Los_Angeles"
     labels:


### PR DESCRIPTION
Update the existing Dependabot configuration to run daily for both
Go modules and GitHub Actions. The repository already covered the
relevant ecosystems in use, so this change only adjusts cadence and
removes the weekly-only day field.

